### PR TITLE
Align site content with official sources

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -23,32 +23,31 @@ export default function Hero() {
 
       {/* Subtle grid pattern overlay */}
       <div className="absolute inset-0 z-10 opacity-10">
-        <div 
+        <div
           className="h-full w-full"
           style={{
             backgroundImage: `
               linear-gradient(rgba(255,255,255,0.1) 1px, transparent 1px),
               linear-gradient(90deg, rgba(255,255,255,0.1) 1px, transparent 1px)
             `,
-            backgroundSize: '50px 50px'
+            backgroundSize: '50px 50px',
           }}
         />
       </div>
 
       {/* Content */}
-      <div className="container mx-auto px-6 relative z-10 text-white max-w-7xl">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center min-h-screen">
-          
+      <div className="container relative z-10 mx-auto max-w-7xl px-6 text-white">
+        <div className="grid min-h-screen grid-cols-1 items-center gap-16 lg:grid-cols-2">
           {/* Left Column - Main Content */}
           <div className="space-y-8">
-            {/* Professional Badge - Styled like "UPCOMING LAUNCH" */}
+            {/* Professional Badge */}
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6 }}
-              className="text-sm font-medium tracking-widest text-gray-400 uppercase"
+              className="text-sm font-medium uppercase tracking-widest text-gray-400"
             >
-              UPCOMING PROJECT
+              COMMERCIAL BUILDERS
             </motion.div>
 
             {/* Main Title - Large and Bold like "ORION ONE MISSION" */}
@@ -56,9 +55,9 @@ export default function Hero() {
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.2 }}
-              className="text-5xl md:text-6xl lg:text-7xl xl:text-8xl font-bold leading-tight"
+              className="text-5xl font-bold leading-tight md:text-6xl lg:text-7xl xl:text-8xl"
             >
-              <span className="block text-white mb-2">DD&B</span>
+              <span className="mb-2 block text-white">DD&B</span>
               <span className="block text-white">CONSTRUCTION</span>
             </motion.h1>
 
@@ -67,7 +66,7 @@ export default function Hero() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.4 }}
-              className="text-xl md:text-2xl text-gray-300 font-light leading-relaxed max-w-lg"
+              className="max-w-lg text-xl font-light leading-relaxed text-gray-300 md:text-2xl"
             >
               {heroContent.subtitle}
             </motion.p>
@@ -77,7 +76,7 @@ export default function Hero() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8, delay: 0.6 }}
-              className="text-gray-400 leading-relaxed max-w-lg"
+              className="max-w-lg leading-relaxed text-gray-400"
             >
               {heroContent.description}
             </motion.p>
@@ -92,7 +91,7 @@ export default function Hero() {
               <motion.button
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
-                className="inline-flex items-center justify-center px-8 py-4 text-sm font-medium tracking-widest uppercase border border-white/30 bg-transparent text-white hover:bg-white hover:text-black transition-all duration-300"
+                className="inline-flex items-center justify-center border border-white/30 bg-transparent px-8 py-4 text-sm font-medium uppercase tracking-widest text-white transition-all duration-300 hover:bg-white hover:text-black"
                 onClick={() => {
                   const element = document.getElementById('services');
                   element?.scrollIntoView({ behavior: 'smooth' });
@@ -104,7 +103,7 @@ export default function Hero() {
           </div>
 
           {/* Right Column - Stats */}
-          <div className="lg:justify-self-end space-y-8">
+          <div className="space-y-8 lg:justify-self-end">
             {/* Key Stats - Vertical layout */}
             <motion.div
               initial={{ opacity: 0, x: 30 }}
@@ -113,18 +112,30 @@ export default function Hero() {
               className="space-y-8"
             >
               <div className="text-right">
-                <div className="text-4xl md:text-5xl font-bold text-white mb-2">43+</div>
-                <div className="text-sm font-medium tracking-wider text-gray-400 uppercase">Years of Excellence</div>
+                <div className="mb-2 text-4xl font-bold text-white md:text-5xl">
+                  43+
+                </div>
+                <div className="text-sm font-medium uppercase tracking-wider text-gray-400">
+                  Years of Excellence
+                </div>
               </div>
-              
+
               <div className="text-right">
-                <div className="text-4xl md:text-5xl font-bold text-white mb-2">100%</div>
-                <div className="text-sm font-medium tracking-wider text-gray-400 uppercase">Completion Rate</div>
+                <div className="mb-2 text-4xl font-bold text-white md:text-5xl">
+                  100%
+                </div>
+                <div className="text-sm font-medium uppercase tracking-wider text-gray-400">
+                  Completion Rate
+                </div>
               </div>
-              
+
               <div className="text-right">
-                <div className="text-4xl md:text-5xl font-bold text-white mb-2">8</div>
-                <div className="text-sm font-medium tracking-wider text-gray-400 uppercase">States Served</div>
+                <div className="mb-2 text-4xl font-bold text-white md:text-5xl">
+                  8
+                </div>
+                <div className="text-sm font-medium uppercase tracking-wider text-gray-400">
+                  States Served
+                </div>
               </div>
             </motion.div>
           </div>
@@ -139,12 +150,18 @@ export default function Hero() {
         className="absolute bottom-8 left-0 right-0 z-20"
       >
         <div className="container mx-auto px-6">
-          <div className="flex justify-between items-center text-xs font-medium tracking-wider text-gray-500 uppercase">
-            <div>DD&B Construction ©2025</div>
+          <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wider text-gray-500">
+            <div>© DD&B Construction, Inc. All rights reserved.</div>
             <div className="flex space-x-8">
-              <span className="hover:text-white transition-colors cursor-pointer">Services</span>
-              <span className="hover:text-white transition-colors cursor-pointer">Projects</span>
-              <span className="hover:text-white transition-colors cursor-pointer">Contact</span>
+              <span className="cursor-pointer transition-colors hover:text-white">
+                Services
+              </span>
+              <span className="cursor-pointer transition-colors hover:text-white">
+                Projects
+              </span>
+              <span className="cursor-pointer transition-colors hover:text-white">
+                Contact
+              </span>
             </div>
           </div>
         </div>
@@ -155,7 +172,7 @@ export default function Hero() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 1, delay: 1.4 }}
-        className="absolute bottom-20 left-1/2 -translate-x-1/2 text-white cursor-pointer group"
+        className="group absolute bottom-20 left-1/2 -translate-x-1/2 cursor-pointer text-white"
         onClick={() => {
           const element = document.getElementById('services');
           element?.scrollIntoView({ behavior: 'smooth' });
@@ -163,8 +180,8 @@ export default function Hero() {
       >
         <motion.div
           animate={{ y: [0, 8, 0] }}
-          transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
-          className="w-[1px] h-16 bg-gradient-to-b from-transparent via-white to-transparent"
+          transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
+          className="h-16 w-[1px] bg-gradient-to-b from-transparent via-white to-transparent"
         />
       </motion.div>
     </section>

--- a/src/components/ServicesGrid.tsx
+++ b/src/components/ServicesGrid.tsx
@@ -3,7 +3,15 @@
 import { motion } from 'framer-motion';
 import Image from 'next/image';
 import { serviceCards } from '@/data/content';
-import { ArrowRightIcon, BuildingOfficeIcon, HomeIcon, WrenchScrewdriverIcon, BuildingLibraryIcon, BuildingStorefrontIcon, AcademicCapIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowRightIcon,
+  BuildingOfficeIcon,
+  HomeIcon,
+  WrenchScrewdriverIcon,
+  BuildingLibraryIcon,
+  BuildingStorefrontIcon,
+  AcademicCapIcon,
+} from '@heroicons/react/24/outline';
 
 const iconMap = {
   'Hotel Construction': BuildingStorefrontIcon,
@@ -31,25 +39,28 @@ export default function ServicesGrid() {
             whileInView={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.6, delay: 0.2 }}
             viewport={{ once: true }}
-            className="inline-flex items-center px-3 py-1 mb-4 rounded-full bg-accent-copper/10 text-accent-copper font-medium text-sm"
+            className="mb-4 inline-flex items-center rounded-full bg-accent-copper/10 px-3 py-1 text-sm font-medium text-accent-copper"
           >
-            <span className="w-2 h-2 bg-accent-copper rounded-full mr-2"></span>
+            <span className="mr-2 h-2 w-2 rounded-full bg-accent-copper"></span>
             Our Services
           </motion.div>
 
-          <h2 className="mb-6 text-3xl md:text-4xl font-bold text-brand-700">
+          <h2 className="mb-6 text-3xl font-bold text-brand-700 md:text-4xl">
             Construction Excellence Across Industries
           </h2>
-          
-          <p className="mx-auto max-w-3xl text-large text-muted leading-relaxed">
-            Specialized construction services delivered by experienced professionals with proven expertise in commercial, hospitality, multi-family, and civic projects.
+
+          <p className="text-large text-muted mx-auto max-w-3xl leading-relaxed">
+            Specialized construction services delivered by experienced
+            professionals with proven expertise in commercial, hospitality,
+            multi-family, and civic projects.
           </p>
         </motion.div>
 
         <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           {serviceCards.map((service, index) => {
-            const IconComponent = iconMap[service.title as keyof typeof iconMap];
-            
+            const IconComponent =
+              iconMap[service.title as keyof typeof iconMap];
+
             return (
               <motion.div
                 key={service.title}
@@ -69,31 +80,28 @@ export default function ServicesGrid() {
                       className="object-cover transition-transform duration-300 group-hover:scale-105"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-brand-900/60 via-brand-900/20 to-transparent"></div>
-                    
+
                     {/* Icon */}
-                    <div className="absolute top-4 right-4 w-12 h-12 bg-white/90 backdrop-blur-sm rounded-lg flex items-center justify-center group-hover:bg-accent-copper group-hover:text-white transition-all duration-200">
-                      {IconComponent && <IconComponent className="w-6 h-6 text-brand-700 group-hover:text-white transition-colors" />}
-                    </div>
-                    
-                    {/* Project Count Badge */}
-                    <div className="absolute bottom-4 left-4 px-3 py-1 bg-accent-copper/90 backdrop-blur-sm rounded-md text-white text-sm font-medium">
-                      {index === 0 ? '150+' : index === 1 ? '75+' : index === 2 ? '200+' : index === 3 ? '25+' : index === 4 ? '30+' : '50+'} Projects
+                    <div className="absolute right-4 top-4 flex h-12 w-12 items-center justify-center rounded-lg bg-white/90 backdrop-blur-sm transition-all duration-200 group-hover:bg-accent-copper group-hover:text-white">
+                      {IconComponent && (
+                        <IconComponent className="h-6 w-6 text-brand-700 transition-colors group-hover:text-white" />
+                      )}
                     </div>
                   </div>
 
                   {/* Card Content */}
                   <div className="p-6">
-                    <h3 className="mb-4 text-xl font-bold text-brand-700 group-hover:text-brand-600 transition-colors duration-200">
+                    <h3 className="mb-4 text-xl font-bold text-brand-700 transition-colors duration-200 group-hover:text-brand-600">
                       {service.title}
                     </h3>
-                    <p className="text-muted leading-relaxed mb-6">
+                    <p className="text-muted mb-6 leading-relaxed">
                       {service.blurb}
                     </p>
-                    
+
                     {/* Learn More Link */}
-                    <button className="inline-flex items-center text-accent-copper font-semibold hover:text-brand-700 transition-colors duration-200">
+                    <button className="inline-flex items-center font-semibold text-accent-copper transition-colors duration-200 hover:text-brand-700">
                       Learn More
-                      <ArrowRightIcon className="w-4 h-4 ml-2 transition-transform duration-200 group-hover:translate-x-1" />
+                      <ArrowRightIcon className="ml-2 h-4 w-4 transition-transform duration-200 group-hover:translate-x-1" />
                     </button>
                   </div>
                 </div>

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -9,7 +9,8 @@ import {
 export const heroContent = {
   title: 'DD&B CONSTRUCTION',
   subtitle: 'Commercial Builders – Building Quality Since 1981',
-  description: 'Ground up commercial builders and general contractors with the expertise and financial stability to complete the project every time. That is DD&B Construction\'s legacy for almost 40 years. With every commercial building construction project, our goal is effective communication, reliability, and safety.',
+  description:
+    "Ground up commercial builders and general contractors with the expertise and financial stability to complete the project every time. That is DD&B Construction's legacy for almost 40 years. With every commercial building construction project, our goal is effective communication, reliability, and safety.",
   ctaText: 'Discuss Your Project',
   backgroundImage: '/images/exterior/SATWO_TX_SATWESTOVER_RI_EXTERIOR_DUSK.jpg',
 };
@@ -36,7 +37,7 @@ export const serviceCards: ServiceCard[] = [
   {
     title: 'Ground-Up Construction',
     blurb:
-      'DD&B Construction delivers turn-key commercial construction services that take a project from the planning stages through site preparation, construction and finish-out. We are there to ensure our clients\' total satisfaction through their move-in day.',
+      "DD&B Construction delivers turn-key commercial construction services that take a project from the planning stages through site preparation, construction and finish-out. We are there to ensure our clients' total satisfaction through their move-in day.",
     img: '/images/exterior/SATWO_TX_SATWESTOVER_RI_EXTERIOR_DUSK.jpg',
   },
   {
@@ -94,7 +95,7 @@ export const timelineEntries: TimelineEntry[] = [
     year: 'Mid-1980s',
     title: 'Mr. Mehta Takes Control',
     description:
-      'Mr. Mehta bought out the initial partners and set the company\'s sights on regional expansion, focusing on building the company\'s reputation for quality work and reliable project completion.',
+      "Mr. Mehta bought out the initial partners and set the company's sights on regional expansion, focusing on building the company's reputation for quality work and reliable project completion.",
   },
   {
     year: '1990s',
@@ -186,7 +187,7 @@ export const safetyProgram: SafetyProgramItem[] = [
   {
     title: 'LEED & Sustainable Construction',
     description:
-      'DD&B Construction works with our clients\' architects and engineers to ensure a smooth construction process while meeting project sustainability requirements. Whether the project is LEED-certified or not, we know that sustainable buildings are now the norm.',
+      "DD&B Construction works with our clients' architects and engineers to ensure a smooth construction process while meeting project sustainability requirements. Whether the project is LEED-certified or not, we know that sustainable buildings are now the norm.",
     points: [
       'LEED-certified project experience',
       'Green building construction expertise',
@@ -200,95 +201,113 @@ export const safetyProgram: SafetyProgramItem[] = [
 export const expertiseAreas = [
   {
     title: 'Hotel Construction',
-    description: 'Specialized expertise in hospitality construction from ground-up development to renovations.',
+    description:
+      'Specialized expertise in hospitality construction from ground-up development to renovations for major brands like Marriott, Hilton, Hyatt and IHG.',
     icon: '🏨',
-    projects: '150+ Hotel Projects Completed'
+    projects: 'Extensive portfolio of hotel projects',
   },
   {
     title: 'Multi-Family Construction',
-    description: 'Apartments, condominiums, and residential complexes with proven track record.',
+    description:
+      'Apartments, condominiums and residential complexes, including a 200‑unit development in Manor, Texas.',
     icon: '🏢',
-    projects: '75+ Multi-Family Developments'
+    projects: 'Trusted partner for multifamily developers',
   },
   {
     title: 'Commercial Office Buildings',
-    description: 'Professional office spaces, retail centers, and mixed-use developments.',
+    description:
+      'Professional office buildings, retail centers and mixed-use developments across the Mid-Atlantic and Texas.',
     icon: '🏢',
-    projects: '200+ Commercial Projects'
+    projects: 'Dozens of commercial projects delivered',
   },
   {
     title: 'Civic & Religious Buildings',
-    description: 'Schools, churches, and public buildings requiring specialized expertise.',
+    description:
+      'Schools, churches and civic buildings including public schools in Maryland and temple projects.',
     icon: '🏛️',
-    projects: '50+ Civic Projects'
+    projects: 'Experienced civic and religious builder',
   },
   {
     title: 'High Rise Construction',
-    description: 'Multi-story commercial buildings with complex structural requirements.',
+    description:
+      'Multi-story commercial buildings with complex structural requirements.',
     icon: '🏗️',
-    projects: '25+ High-Rise Projects'
+    projects: 'Proven high‑rise expertise',
   },
   {
     title: 'Modular Construction',
-    description: 'Innovative modular construction techniques for efficient project delivery.',
+    description:
+      'Innovative modular construction techniques for efficient project delivery.',
     icon: '🔧',
-    projects: '30+ Modular Projects'
-  }
+    projects: 'Modular solutions for accelerated schedules',
+  },
 ];
 
 export const companyInfo = {
-  tagline: "A Foundation of Achievement",
-  description: "DD&B Construction is built on a foundation of hard work, honest business practices, and a desire to achieve. Ground up commercial builders and general contractors with the expertise and financial stability to complete the project every time.",
-  goals: "With every commercial building construction project, our goal is effective communication, reliability, and safety.",
-  specialties: "DD&B Construction has made a name for itself for its work in hotel construction, multi-family construction of apartments and condos, the construction of schools, churches and other religious buildings, and commercial building construction, including retail centers and office buildings.",
-  founder: "The company was founded by Dolat Mehta, a civil engineer from India who first arrived in the United States in 1971.",
-  regions: "Serving the Mid-Atlantic region including Maryland, Virginia, New Jersey, Washington D.C., Pennsylvania, and Delaware",
-  headquarters: "17B Firstfield Road, Suite #203, Gaithersburg, Maryland 20878",
-  westOffice: "7300 Blanco Road, Suite 708, San Antonio, Texas 78216",
-  phonesMD: "301-869-8415",
-  phoneTX: "210-298-4499"
+  tagline: 'A Foundation of Achievement',
+  description:
+    'DD&B Construction is built on a foundation of hard work, honest business practices, and a desire to achieve. Ground up commercial builders and general contractors with the expertise and financial stability to complete the project every time.',
+  goals:
+    'With every commercial building construction project, our goal is effective communication, reliability, and safety.',
+  specialties:
+    'DD&B Construction has made a name for itself for its work in hotel construction, multi-family construction of apartments and condos, the construction of schools, churches and other religious buildings, and commercial building construction, including retail centers and office buildings.',
+  founder:
+    'The company was founded by Dolat Mehta, a civil engineer from India who first arrived in the United States in 1971.',
+  regions:
+    'Serving the Mid-Atlantic region including Maryland, Virginia, New Jersey, Washington D.C., Pennsylvania, and Delaware',
+  headquarters: '17B Firstfield Road, Suite #203, Gaithersburg, Maryland 20878',
+  westOffice: '7300 Blanco Road, Suite 708, San Antonio, Texas 78216',
+  phonesMD: '301-869-8415',
+  phoneTX: '210-298-4499',
 };
 
 // Awards and Recognition
 export const awards = [
   {
-    title: "ENR Top 400 Contractors",
-    year: "2024",
-    description: "Recognized among the nation's top construction contractors"
+    title: 'Best Hotel Contractors in San Antonio',
+    year: '2021',
+    description:
+      'Recognized by SanAntonioArchitects.org for excellence in hospitality construction',
   },
   {
-    title: "TEXO Building Excellence Award",
-    year: "2023",
-    description: "Outstanding achievement in commercial construction"
+    title: 'Bonding Agent Endorsement',
+    year: '1984–Present',
+    description:
+      'Marsh & McLennan notes DD&B has never had a bond request declined',
   },
   {
-    title: "40+ Years Excellence",
-    year: "2021",
-    description: "Celebrating four decades of quality construction"
+    title: '40+ Years of Excellence',
+    year: '1981–Present',
+    description:
+      'Over four decades of quality construction across multiple states',
   },
   {
-    title: "100% Completion Rate",
-    year: "Ongoing",
-    description: "Maintained perfect project completion record"
-  }
+    title: '100% Completion Rate',
+    year: 'Ongoing',
+    description: 'Maintained a perfect project completion record',
+  },
 ];
 
 // Company Culture and Values
 export const companyValues = [
   {
-    title: "Communication",
-    description: "DD&B knows what is important to clients: Communication. Clear, consistent communication throughout every project."
+    title: 'Communication',
+    description:
+      'DD&B knows what is important to clients: Communication. Clear, consistent communication throughout every project.',
   },
   {
-    title: "Expertise",
-    description: "Over 40 years of construction expertise and proven proficiency across multiple sectors and building types."
+    title: 'Expertise',
+    description:
+      'Over 40 years of construction expertise and proven proficiency across multiple sectors and building types.',
   },
   {
-    title: "Reliability",
-    description: "Financial stability and 100% project completion record ensures reliable project delivery every time."
+    title: 'Reliability',
+    description:
+      'Financial stability and 100% project completion record ensures reliable project delivery every time.',
   },
   {
-    title: "Quality Work",
-    description: "Honest business practices and a desire to achieve excellence in every commercial construction project."
-  }
+    title: 'Quality Work',
+    description:
+      'Honest business practices and a desire to achieve excellence in every commercial construction project.',
+  },
 ];


### PR DESCRIPTION
## Summary
- remove project count badges and extraneous banner text
- bring hero badge and footer text in line with DD&B website
- update expertise areas with text from official blurb
- revise awards list to reflect documented recognition

## Testing
- `npx prettier --write src/components/Hero.tsx src/components/ServicesGrid.tsx src/data/content.ts`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687e76b0e7748328826d49407f27c462